### PR TITLE
Update scripts to work with current SIMH 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+4.1_BSD_19810710-modified.tap
+rp06bsd
+rp06v8
+rp06v8_prep
+rp06work
+v8.tap
+v8jerq.tap

--- a/fixupV8
+++ b/fixupV8
@@ -9,6 +9,7 @@ source common.tcl
 exec cp rp06v8_prep rp06v8
 
 proc boot { } {
+    simh "set noasync"
     simh "set tto 7b"
     simh "set dz lines=8"
     simh "set rp0 rp06"

--- a/install41BSD
+++ b/install41BSD
@@ -9,11 +9,11 @@ exec rm -f rp06bsd
 
 spawn vax780
 
+simh "set noasync"
 simh "set tto 7b"
 simh "set dz lines=8"
 simh "set rp0 rp06"
 simh "at rp0 rp06bsd"
-expect "Overwrite last track?" { after 1000 { sendline "" } }
 simh "set tu0 te16"
 simh "at tu0 4.1_BSD_19810710-modified.tap"
 

--- a/installV8
+++ b/installV8
@@ -11,6 +11,7 @@ exec cp rp06bsd rp06v8_prep
 spawn vax780
 
 # boot disk with bootBsd file image
+simh "set noasync"
 simh "set tto 7b"
 simh "set dz lines=8"
 simh "set rp0 rp06"

--- a/run.conf
+++ b/run.conf
@@ -1,3 +1,4 @@
+set noasync
 set tto 7b
 set dz lines=8
 att dz -m 8888


### PR DESCRIPTION
This change updates the scripts to work with current SIMH 4.0 from GitHub.

- Set 'noasync' to prevent disk errors
- Don't pause and wait for disk resize confirmation
- Add .gitignore for files that should not make it to git